### PR TITLE
Fixed swapped parameters bug

### DIFF
--- a/gbgenie.py
+++ b/gbgenie.py
@@ -22,7 +22,7 @@ def rl8(n, shift):
     return ((n << shift) | (n >> (8 - shift))) & 0xff
 
 
-def encode(val, addr, orig=None):
+def encode(addr, val, orig=None):
     code = '%02X' % val
     code += '%X-%02X%X' % ((addr & 0xf00) >> 8, addr & 0xff, 0xf - (addr >> 12))
 


### PR DESCRIPTION
There is a bug where the address and the val parameters are swapped. I noticed and now it generates the right codes.